### PR TITLE
Fix NullPointer exception when there is no outputDirectory

### DIFF
--- a/src/main/java/fr/ina/research/amalia/tools/ConvertSubripToMetadata.java
+++ b/src/main/java/fr/ina/research/amalia/tools/ConvertSubripToMetadata.java
@@ -68,7 +68,7 @@ public class ConvertSubripToMetadata {
 		
 		File outputFile = new File(args[1]);
 		File outputDirectory = outputFile.getParentFile(); 
-		if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
+		if (outputDirectory != null && !outputDirectory.exists() && !outputDirectory.mkdirs()) {
 			System.err.println("Unable to create directories for : " + outputFile.getAbsolutePath());
 			usage();
 		}


### PR DESCRIPTION
When giving just a filename as the outputFile, there is no parent file, so outputDirectory is set to null.
